### PR TITLE
fix(tools): update jsonschema struct tags for MCP SDK v1.1.0

### DIFF
--- a/internal/tools/labels.go
+++ b/internal/tools/labels.go
@@ -19,9 +19,9 @@ const (
 
 // LabelsParams defines the parameters for the loki_labels tool.
 type LabelsParams struct {
-	Name  string `json:"name,omitempty"  jsonschema:"description=Label name to get values for. If omitted returns all label names"`
-	Start string `json:"start,omitempty" jsonschema:"description=Start time (RFC3339 or relative like 1h)"`
-	End   string `json:"end,omitempty"   jsonschema:"description=End time (RFC3339 or now)"`
+	Name  string `json:"name,omitempty"  jsonschema:"Label name to get values for. If omitted returns all label names"`
+	Start string `json:"start,omitempty" jsonschema:"Start time (RFC3339 or relative like 1h)"`
+	End   string `json:"end,omitempty"   jsonschema:"End time (RFC3339 or now)"`
 }
 
 // LabelsResult is the output of the loki_labels tool.

--- a/internal/tools/query.go
+++ b/internal/tools/query.go
@@ -31,11 +31,11 @@ var ErrInvalidTimeFormat = errors.New("invalid time format")
 
 // QueryParams defines the parameters for the loki_query tool.
 type QueryParams struct {
-	Query     string `json:"query"               jsonschema:"description=LogQL query string,required"`
-	Start     string `json:"start,omitempty"     jsonschema:"description=Start time (RFC3339 or relative like 1h)"`
-	End       string `json:"end,omitempty"       jsonschema:"description=End time (RFC3339 or now)"`
-	Limit     int    `json:"limit,omitempty"     jsonschema:"description=Maximum entries to return (default 100)"`
-	Direction string `json:"direction,omitempty" jsonschema:"description=Log order: forward or backward (default backward)"`
+	Query     string `json:"query"               jsonschema:"LogQL query string"`
+	Start     string `json:"start,omitempty"     jsonschema:"Start time (RFC3339 or relative like 1h)"`
+	End       string `json:"end,omitempty"       jsonschema:"End time (RFC3339 or now)"`
+	Limit     int    `json:"limit,omitempty"     jsonschema:"Maximum entries to return (default 100)"`
+	Direction string `json:"direction,omitempty" jsonschema:"Log order: forward or backward (default backward)"`
 }
 
 // QueryResult is the output of the loki_query tool.

--- a/internal/tools/series.go
+++ b/internal/tools/series.go
@@ -18,9 +18,9 @@ var ErrMatchRequired = errors.New("match parameter is required")
 
 // SeriesParams defines the parameters for the loki_series tool.
 type SeriesParams struct {
-	Match []string `json:"match"           jsonschema:"description=Series selectors (e.g. {app=nginx}),required"`
-	Start string   `json:"start,omitempty" jsonschema:"description=Start time (RFC3339 or relative like 1h)"`
-	End   string   `json:"end,omitempty"   jsonschema:"description=End time (RFC3339 or now)"`
+	Match []string `json:"match"           jsonschema:"Series selectors (e.g. {app=nginx})"`
+	Start string   `json:"start,omitempty" jsonschema:"Start time (RFC3339 or relative like 1h)"`
+	End   string   `json:"end,omitempty"   jsonschema:"End time (RFC3339 or now)"`
 }
 
 // SeriesResult is the output of the loki_series tool.

--- a/internal/tools/stats.go
+++ b/internal/tools/stats.go
@@ -19,9 +19,9 @@ const (
 
 // StatsParams defines the parameters for the loki_stats tool.
 type StatsParams struct {
-	Query string `json:"query"           jsonschema:"description=LogQL selector (e.g. {app=nginx}),required"`
-	Start string `json:"start,omitempty" jsonschema:"description=Start time (RFC3339 or relative like 1h)"`
-	End   string `json:"end,omitempty"   jsonschema:"description=End time (RFC3339 or now)"`
+	Query string `json:"query"           jsonschema:"LogQL selector (e.g. {app=nginx})"`
+	Start string `json:"start,omitempty" jsonschema:"Start time (RFC3339 or relative like 1h)"`
+	End   string `json:"end,omitempty"   jsonschema:"End time (RFC3339 or now)"`
 }
 
 // StatsResult is the output of the loki_stats tool.


### PR DESCRIPTION
## Summary

Fix panic at startup caused by incompatible jsonschema struct tags with MCP SDK v1.1.0.

## Changes

- Remove `description=` prefix from jsonschema tags (SDK now expects plain description text)
- Remove `,required` suffix from jsonschema tags (required determined by `omitempty` in json tag)
- Update all tool parameter structs: QueryParams, LabelsParams, SeriesParams, StatsParams

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed — verified all 4 tools work against live Loki instance

## Documentation

- [x] README updated (if needed) — N/A, no doc changes needed
- [x] Code comments added for complex logic — N/A

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — N/A
- [x] Related issues referenced (if any) — N/A

## Additional Notes

Error was:
```
panic: AddTool: tool "loki_query": input schema: ForType(tools.QueryParams):
tag must not begin with 'WORD=': "description=LogQL query string,required"
```