### PR TITLE
feat(tools): add loki_ready and loki_config tools

### DIFF
--- a/cmd/mcp-loki/main.go
+++ b/cmd/mcp-loki/main.go
@@ -83,6 +83,8 @@ func registerTools(server *mcp.Server, client *loki.Client) {
 	mcp.AddTool(server, tools.LabelsTool(), tools.NewLabelsHandler(client))
 	mcp.AddTool(server, tools.SeriesTool(), tools.NewSeriesHandler(client))
 	mcp.AddTool(server, tools.StatsTool(), tools.NewStatsHandler(client))
+	mcp.AddTool(server, tools.ReadyTool(), tools.NewReadyHandler(client))
+	mcp.AddTool(server, tools.ConfigTool(), tools.NewConfigHandler(client))
 }
 
 func runHTTPServer(ctx context.Context, server *mcp.Server, port string) {

--- a/internal/tools/config.go
+++ b/internal/tools/config.go
@@ -1,0 +1,44 @@
+package tools
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/lexfrei/mcp-loki/internal/loki"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ConfigParams defines the parameters for the loki_config tool.
+type ConfigParams struct{}
+
+// ConfigResult is the output of the loki_config tool.
+type ConfigResult struct {
+	Config string `json:"config"`
+}
+
+// NewConfigHandler creates a handler for the loki_config tool.
+func NewConfigHandler(client *loki.Client) mcp.ToolHandlerFor[ConfigParams, ConfigResult] {
+	return func(
+		ctx context.Context,
+		_ *mcp.CallToolRequest,
+		_ ConfigParams,
+	) (*mcp.CallToolResult, ConfigResult, error) {
+		config, err := client.Config(ctx)
+		if err != nil {
+			return &mcp.CallToolResult{IsError: true}, ConfigResult{}, errors.Wrap(err, "failed to get config")
+		}
+
+		return nil, ConfigResult{
+			Config: config,
+		}, nil
+	}
+}
+
+// ConfigTool returns the MCP tool definition for loki_config.
+func ConfigTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name:        "loki_config",
+		Description: "Get Loki server configuration (YAML format)",
+	}
+}

--- a/internal/tools/config_test.go
+++ b/internal/tools/config_test.go
@@ -1,0 +1,95 @@
+package tools_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lexfrei/mcp-loki/internal/loki"
+	"github.com/lexfrei/mcp-loki/internal/tools"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestConfigHandler_Success(t *testing.T) {
+	configYAML := `server:
+  http_listen_port: 3100
+ingester:
+  lifecycler:
+    ring:
+      replication_factor: 1`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/config" {
+			t.Errorf("expected path /config, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "text/yaml")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(configYAML))
+	}))
+	defer server.Close()
+
+	client := loki.NewClient(server.URL, "", "", "", "")
+	handler := tools.NewConfigHandler(client)
+
+	result, output, err := handler(context.Background(), &mcp.CallToolRequest{}, tools.ConfigParams{})
+	if err != nil {
+		t.Fatalf("handler failed: %v", err)
+	}
+
+	if result != nil && result.IsError {
+		t.Error("expected success, got error")
+	}
+
+	if output.Config == "" {
+		t.Error("expected non-empty config")
+	}
+
+	if output.Config != configYAML {
+		t.Errorf("config mismatch: got %s", output.Config)
+	}
+}
+
+func TestConfigHandler_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	client := loki.NewClient(server.URL, "", "", "", "")
+	handler := tools.NewConfigHandler(client)
+
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, tools.ConfigParams{})
+
+	// Should return error
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for failed config request")
+	}
+}
+
+func TestConfigHandler_ConnectionError(t *testing.T) {
+	// Non-existent server
+	client := loki.NewClient("http://localhost:59999", "", "", "", "")
+	handler := tools.NewConfigHandler(client)
+
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, tools.ConfigParams{})
+
+	// Should handle connection error gracefully
+	if err == nil && (result == nil || !result.IsError) {
+		t.Error("expected error for connection error")
+	}
+}
+
+func TestConfigTool_Definition(t *testing.T) {
+	tool := tools.ConfigTool()
+
+	if tool.Name != "loki_config" {
+		t.Errorf("expected name loki_config, got %s", tool.Name)
+	}
+
+	if tool.Description == "" {
+		t.Error("expected non-empty description")
+	}
+}

--- a/internal/tools/ready.go
+++ b/internal/tools/ready.go
@@ -1,0 +1,49 @@
+package tools
+
+import (
+	"context"
+
+	"github.com/lexfrei/mcp-loki/internal/loki"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ReadyParams defines the parameters for the loki_ready tool.
+type ReadyParams struct{}
+
+// ReadyResult is the output of the loki_ready tool.
+type ReadyResult struct {
+	Ready   bool   `json:"ready"`
+	Message string `json:"message"`
+}
+
+// NewReadyHandler creates a handler for the loki_ready tool.
+func NewReadyHandler(client *loki.Client) mcp.ToolHandlerFor[ReadyParams, ReadyResult] {
+	return func(
+		ctx context.Context,
+		_ *mcp.CallToolRequest,
+		_ ReadyParams,
+	) (*mcp.CallToolResult, ReadyResult, error) {
+		readyErr := client.Ready(ctx)
+
+		// Always return a result, never an error
+		// This allows LLMs to check readiness without error handling
+		result := ReadyResult{
+			Ready:   readyErr == nil,
+			Message: "Loki is ready",
+		}
+
+		if readyErr != nil {
+			result.Message = readyErr.Error()
+		}
+
+		return nil, result, nil
+	}
+}
+
+// ReadyTool returns the MCP tool definition for loki_ready.
+func ReadyTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name:        "loki_ready",
+		Description: "Check if Loki is ready to accept requests",
+	}
+}

--- a/internal/tools/ready_test.go
+++ b/internal/tools/ready_test.go
@@ -1,0 +1,87 @@
+package tools_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lexfrei/mcp-loki/internal/loki"
+	"github.com/lexfrei/mcp-loki/internal/tools"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestReadyHandler_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ready" {
+			t.Errorf("expected path /ready, got %s", r.URL.Path)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ready"))
+	}))
+	defer server.Close()
+
+	client := loki.NewClient(server.URL, "", "", "", "")
+	handler := tools.NewReadyHandler(client)
+
+	result, output, err := handler(context.Background(), &mcp.CallToolRequest{}, tools.ReadyParams{})
+	if err != nil {
+		t.Fatalf("handler failed: %v", err)
+	}
+
+	if result != nil && result.IsError {
+		t.Error("expected success, got error")
+	}
+
+	if !output.Ready {
+		t.Error("expected Ready=true")
+	}
+}
+
+func TestReadyHandler_NotReady(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("not ready"))
+	}))
+	defer server.Close()
+
+	client := loki.NewClient(server.URL, "", "", "", "")
+	handler := tools.NewReadyHandler(client)
+
+	result, output, err := handler(context.Background(), &mcp.CallToolRequest{}, tools.ReadyParams{})
+
+	// Should return error or IsError=true, but not panic
+	if err == nil && (result == nil || !result.IsError) {
+		if output.Ready {
+			t.Error("expected Ready=false for unavailable server")
+		}
+	}
+}
+
+func TestReadyHandler_ConnectionError(t *testing.T) {
+	// Non-existent server
+	client := loki.NewClient("http://localhost:59999", "", "", "", "")
+	handler := tools.NewReadyHandler(client)
+
+	result, output, err := handler(context.Background(), &mcp.CallToolRequest{}, tools.ReadyParams{})
+
+	// Should handle connection error gracefully
+	if err == nil && (result == nil || !result.IsError) {
+		if output.Ready {
+			t.Error("expected Ready=false for connection error")
+		}
+	}
+}
+
+func TestReadyTool_Definition(t *testing.T) {
+	tool := tools.ReadyTool()
+
+	if tool.Name != "loki_ready" {
+		t.Errorf("expected name loki_ready, got %s", tool.Name)
+	}
+
+	if tool.Description == "" {
+		t.Error("expected non-empty description")
+	}
+}


### PR DESCRIPTION
## Summary

Add two new MCP tools for Loki health checking and configuration inspection.

## Changes

- `loki_ready` — check if Loki is ready to accept requests (GET /ready)
- `loki_config` — get Loki server configuration in YAML format (GET /config)

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run`)
- [x] TDD approach: tests written first

## Checklist

- [x] Commit messages follow semantic format
- [x] No secrets or credentials in code