### PR TITLE
fix(lint): clear goconst findings and migrate renovate to shared preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,41 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "platformAutomerge": true,
-  "automergeStrategy": "squash",
   "extends": [
-    "config:recommended",
+    "github>lexfrei/renovate-config",
     "docker:enableMajor",
-    ":separateMajorReleases",
-    ":prHourlyLimitNone",
-    ":prConcurrentLimitNone"
+    ":separateMajorReleases"
   ],
-  "labels": ["dependencies"],
   "rangeStrategy": "pin",
-  "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
-    {
-      "description": "Group all Go module updates",
-      "matchManagers": ["gomod"],
-      "groupName": "go modules",
-      "groupSlug": "go-modules"
-    },
-    {
-      "description": "Group all GitHub Actions updates",
-      "matchManagers": ["github-actions"],
-      "groupName": "github actions",
-      "groupSlug": "github-actions"
-    },
-    {
-      "description": "Automerge patch updates for Go modules",
-      "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["patch"],
-      "automerge": true
-    },
-    {
-      "description": "Automerge all GitHub Actions updates including major",
-      "matchManagers": ["github-actions"],
-      "automerge": true
-    },
     {
       "description": "Pin Go version in Containerfile",
       "matchManagers": ["dockerfile"],
@@ -47,7 +18,7 @@
     {
       "customType": "regex",
       "description": "Update Go version in GitHub Actions",
-      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
+      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
       "matchStrings": [
         "go-version:\\s*['\"]?(?<currentValue>[\\d.]+)['\"]?"
       ],
@@ -57,7 +28,7 @@
     {
       "customType": "regex",
       "description": "Update Go version directive in go.mod",
-      "fileMatch": ["(^|/)go\\.mod$"],
+      "managerFilePatterns": ["/(^|/)go\\.mod$/"],
       "matchStrings": [
         "^go (?<currentValue>[\\d.]+)$"
       ],

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,3 +35,6 @@ jobs:
           go-version-file: go.mod
 
       - uses: golangci/golangci-lint-action@v9.2.1
+        with:
+          # renovate: datasource=github-releases depName=golangci/golangci-lint
+          version: v2.12.2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,7 +56,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9.2.1
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=golangci/golangci-lint
+          version: v2.12.2
           args: --timeout=5m
 
       - name: markdownlint

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,11 @@ import (
 	"github.com/lexfrei/mcp-loki/internal/config"
 )
 
+const (
+	testUsername = "user"
+	testPassword = "pass"
+)
+
 func TestLoad_Defaults(t *testing.T) {
 	t.Setenv("LOKI_URL", "")
 	t.Setenv("LOKI_USERNAME", "")
@@ -83,9 +88,9 @@ func TestConfig_HasBasicAuth(t *testing.T) {
 		password string
 		want     bool
 	}{
-		{"both set", "user", "pass", true},
-		{"only username", "user", "", false},
-		{"only password", "", "pass", false},
+		{"both set", testUsername, testPassword, true},
+		{"only username", testUsername, "", false},
+		{"only password", "", testPassword, false},
 		{"neither set", "", "", false},
 	}
 

--- a/internal/loki/client_test.go
+++ b/internal/loki/client_test.go
@@ -26,10 +26,10 @@ func TestClient_QueryRange(t *testing.T) {
 		resp := loki.QueryResponse{
 			Status: statusSuccess,
 			Data: loki.QueryData{
-				ResultType: "streams",
+				ResultType: resultTypeStreams,
 				Result: []loki.StreamResult{
 					{
-						Stream: map[string]string{"app": "test"},
+						Stream: map[string]string{labelApp: "test"},
 						Values: [][]json.RawMessage{
 							{json.RawMessage(`"1609459200000000000"`), json.RawMessage(`"test log"`)},
 						},
@@ -71,7 +71,7 @@ func TestClient_Labels(t *testing.T) {
 
 		resp := loki.LabelsResponse{
 			Status: statusSuccess,
-			Data:   []string{"app", "env", "host"},
+			Data:   []string{labelApp, labelEnv, labelHost},
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -107,7 +107,7 @@ func TestClient_LabelValues(t *testing.T) {
 
 		resp := loki.LabelsResponse{
 			Status: statusSuccess,
-			Data:   []string{"nginx", "redis", "postgres"},
+			Data:   []string{appNginx, "redis", "postgres"},
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -121,7 +121,7 @@ func TestClient_LabelValues(t *testing.T) {
 
 	client := loki.NewClient(server.URL, "", "", "", "")
 
-	resp, err := client.LabelValues(context.Background(), "app", time.Now().Add(-time.Hour), time.Now())
+	resp, err := client.LabelValues(context.Background(), labelApp, time.Now().Add(-time.Hour), time.Now())
 	if err != nil {
 		t.Fatalf("LabelValues failed: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestClient_Series(t *testing.T) {
 		resp := loki.SeriesResponse{
 			Status: statusSuccess,
 			Data: []map[string]string{
-				{"app": "nginx", "env": "prod"},
+				{labelApp: appNginx, labelEnv: "prod"},
 			},
 		}
 
@@ -291,8 +291,8 @@ func TestClient_ErrorResponse(t *testing.T) {
 		w.WriteHeader(http.StatusBadRequest)
 
 		resp := loki.ErrorResponse{
-			Status:    "error",
-			ErrorType: "bad_data",
+			Status:    statusError,
+			ErrorType: errorTypeBadData,
 			Error:     "invalid query",
 		}
 

--- a/internal/loki/types_test.go
+++ b/internal/loki/types_test.go
@@ -7,7 +7,17 @@ import (
 	"github.com/lexfrei/mcp-loki/internal/loki"
 )
 
-const appNginx = "nginx"
+const (
+	appNginx = "nginx"
+
+	resultTypeStreams = "streams"
+	statusError       = "error"
+	errorTypeBadData  = "bad_data"
+
+	labelApp  = "app"
+	labelEnv  = "env"
+	labelHost = "host"
+)
 
 func TestQueryResponse_Unmarshal_Streams(t *testing.T) {
 	raw := `{
@@ -36,7 +46,7 @@ func TestQueryResponse_Unmarshal_Streams(t *testing.T) {
 		t.Errorf("expected status success, got %s", resp.Status)
 	}
 
-	if resp.Data.ResultType != "streams" {
+	if resp.Data.ResultType != resultTypeStreams {
 		t.Errorf("expected resultType streams, got %s", resp.Data.ResultType)
 	}
 
@@ -45,8 +55,8 @@ func TestQueryResponse_Unmarshal_Streams(t *testing.T) {
 	}
 
 	stream := resp.Data.Result[0]
-	if stream.Stream["app"] != appNginx {
-		t.Errorf("expected stream app=nginx, got %s", stream.Stream["app"])
+	if stream.Stream[labelApp] != appNginx {
+		t.Errorf("expected stream app=nginx, got %s", stream.Stream[labelApp])
 	}
 
 	values := stream.GetValues()
@@ -107,7 +117,7 @@ func TestLabelsResponse_Unmarshal(t *testing.T) {
 		t.Fatalf("expected 4 labels, got %d", len(resp.Data))
 	}
 
-	expected := []string{"app", "env", "host", "level"}
+	expected := []string{labelApp, labelEnv, labelHost, "level"}
 	for i, label := range expected {
 		if resp.Data[i] != label {
 			t.Errorf("expected label %s at index %d, got %s", label, i, resp.Data[i])
@@ -138,12 +148,12 @@ func TestSeriesResponse_Unmarshal(t *testing.T) {
 		t.Fatalf("expected 2 series, got %d", len(resp.Data))
 	}
 
-	if resp.Data[0]["app"] != appNginx {
-		t.Errorf("expected app=nginx, got %s", resp.Data[0]["app"])
+	if resp.Data[0][labelApp] != appNginx {
+		t.Errorf("expected app=nginx, got %s", resp.Data[0][labelApp])
 	}
 
-	if resp.Data[1]["env"] != "staging" {
-		t.Errorf("expected env=staging, got %s", resp.Data[1]["env"])
+	if resp.Data[1][labelEnv] != "staging" {
+		t.Errorf("expected env=staging, got %s", resp.Data[1][labelEnv])
 	}
 }
 
@@ -198,11 +208,11 @@ func TestErrorResponse_Unmarshal(t *testing.T) {
 		t.Fatalf("failed to unmarshal: %v", err)
 	}
 
-	if resp.Status != "error" {
+	if resp.Status != statusError {
 		t.Errorf("expected status error, got %s", resp.Status)
 	}
 
-	if resp.ErrorType != "bad_data" {
+	if resp.ErrorType != errorTypeBadData {
 		t.Errorf("expected errorType bad_data, got %s", resp.ErrorType)
 	}
 

--- a/internal/tools/labels_test.go
+++ b/internal/tools/labels_test.go
@@ -20,8 +20,8 @@ func TestLabelsHandler_GetAllLabels(t *testing.T) {
 		}
 
 		resp := loki.LabelsResponse{
-			Status: "success",
-			Data:   []string{"app", "env", "host", "level"},
+			Status: statusSuccess,
+			Data:   []string{argApp, argEnv, "host", "level"},
 		}
 		w.Header().Set("Content-Type", "application/json")
 
@@ -58,8 +58,8 @@ func TestLabelsHandler_GetLabelValues(t *testing.T) {
 		}
 
 		resp := loki.LabelsResponse{
-			Status: "success",
-			Data:   []string{"nginx", "redis", "postgres"},
+			Status: statusSuccess,
+			Data:   []string{valueNginx, "redis", "postgres"},
 		}
 		w.Header().Set("Content-Type", "application/json")
 
@@ -74,7 +74,7 @@ func TestLabelsHandler_GetLabelValues(t *testing.T) {
 	handler := tools.NewLabelsHandler(client)
 
 	params := tools.LabelsParams{
-		Name: "app",
+		Name: argApp,
 	}
 
 	result, output, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
@@ -100,7 +100,7 @@ func TestLabelsHandler_WithTimeRange(t *testing.T) {
 			t.Error("expected start and end parameters")
 		}
 
-		resp := loki.LabelsResponse{Status: "success", Data: []string{}}
+		resp := loki.LabelsResponse{Status: statusSuccess, Data: []string{}}
 		w.Header().Set("Content-Type", "application/json")
 
 		err := json.NewEncoder(w).Encode(resp)
@@ -114,8 +114,8 @@ func TestLabelsHandler_WithTimeRange(t *testing.T) {
 	handler := tools.NewLabelsHandler(client)
 
 	params := tools.LabelsParams{
-		Start: "1h",
-		End:   "now",
+		Start: timerange1h,
+		End:   timeNow,
 	}
 
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
@@ -129,7 +129,7 @@ func TestLabelsHandler_InvalidStartTime(t *testing.T) {
 	handler := tools.NewLabelsHandler(client)
 
 	params := tools.LabelsParams{
-		Start: "not-a-time",
+		Start: timeNotParsable,
 	}
 
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)

--- a/internal/tools/prompts.go
+++ b/internal/tools/prompts.go
@@ -11,7 +11,17 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const defaultInterval = "5m"
+const (
+	defaultInterval = "5m"
+
+	argSelector = "selector"
+	argInterval = "interval"
+
+	roleUser = "user"
+
+	descSelector = "LogQL stream selector (e.g. {app=\"nginx\"})"
+	descInterval = "Rate interval (e.g. 5m, 1h). Default: 5m"
+)
 
 var (
 	relativeDurationRe = regexp.MustCompile(`^\d+[smhdw]$`)
@@ -90,7 +100,7 @@ func ErrorLogsHandler() mcp.PromptHandler {
 			Description: fmt.Sprintf("Error logs for %s (last %s)", app, timerange),
 			Messages: []*mcp.PromptMessage{
 				{
-					Role: "user",
+					Role: roleUser,
 					Content: &mcp.TextContent{
 						Text: fmt.Sprintf(
 							"Use the loki_query tool to find error logs:\n\n"+
@@ -114,13 +124,13 @@ func RateQueryPrompt() *mcp.Prompt {
 		Description: "Calculate the rate of log lines matching a selector",
 		Arguments: []*mcp.PromptArgument{
 			{
-				Name:        "selector",
-				Description: "LogQL stream selector (e.g. {app=\"nginx\"})",
+				Name:        argSelector,
+				Description: descSelector,
 				Required:    true,
 			},
 			{
-				Name:        "interval",
-				Description: "Rate interval (e.g. 5m, 1h). Default: 5m",
+				Name:        argInterval,
+				Description: descInterval,
 				Required:    false,
 			},
 		},
@@ -130,7 +140,7 @@ func RateQueryPrompt() *mcp.Prompt {
 // RateQueryHandler returns the handler for the rate_query prompt.
 func RateQueryHandler() mcp.PromptHandler {
 	return func(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
-		selector := req.Params.Arguments["selector"]
+		selector := req.Params.Arguments[argSelector]
 		if selector == "" {
 			return nil, validationErr(errors.New("selector argument is required"))
 		}
@@ -140,7 +150,7 @@ func RateQueryHandler() mcp.PromptHandler {
 			return nil, err
 		}
 
-		interval := req.Params.Arguments["interval"]
+		interval := req.Params.Arguments[argInterval]
 		if interval == "" {
 			interval = defaultInterval
 		} else {
@@ -156,7 +166,7 @@ func RateQueryHandler() mcp.PromptHandler {
 			Description: fmt.Sprintf("Rate query for %s over %s intervals", selector, interval),
 			Messages: []*mcp.PromptMessage{
 				{
-					Role: "user",
+					Role: roleUser,
 					Content: &mcp.TextContent{
 						Text: fmt.Sprintf(
 							"Use the loki_query tool to calculate log rate:\n\n"+
@@ -179,8 +189,8 @@ func TopLabelValuesPrompt() *mcp.Prompt {
 		Description: "Find top N values for a label by log volume",
 		Arguments: []*mcp.PromptArgument{
 			{
-				Name:        "selector",
-				Description: "LogQL stream selector (e.g. {app=\"nginx\"})",
+				Name:        argSelector,
+				Description: descSelector,
 				Required:    true,
 			},
 			{
@@ -194,8 +204,8 @@ func TopLabelValuesPrompt() *mcp.Prompt {
 				Required:    false,
 			},
 			{
-				Name:        "interval",
-				Description: "Rate interval (e.g. 5m, 1h). Default: 5m",
+				Name:        argInterval,
+				Description: descInterval,
 				Required:    false,
 			},
 		},
@@ -207,7 +217,7 @@ type topLabelValuesArgs struct {
 }
 
 func parseTopLabelValuesArgs(args map[string]string) (*topLabelValuesArgs, error) {
-	selector := args["selector"]
+	selector := args[argSelector]
 	if selector == "" {
 		return nil, validationErr(errors.New("selector argument is required"))
 	}
@@ -239,7 +249,7 @@ func parseTopLabelValuesArgs(args map[string]string) (*topLabelValuesArgs, error
 		}
 	}
 
-	interval := args["interval"]
+	interval := args[argInterval]
 	if interval == "" {
 		interval = defaultInterval
 	} else {
@@ -267,7 +277,7 @@ func TopLabelValuesHandler() mcp.PromptHandler {
 			Description: fmt.Sprintf("Top %s %s values by log volume", parsed.n, parsed.label),
 			Messages: []*mcp.PromptMessage{
 				{
-					Role: "user",
+					Role: roleUser,
 					Content: &mcp.TextContent{
 						Text: fmt.Sprintf(
 							"Use the loki_query tool to find top label values:\n\n"+

--- a/internal/tools/prompts_test.go
+++ b/internal/tools/prompts_test.go
@@ -16,6 +16,34 @@ const (
 	promptTopLabelValues = "top_label_values"
 )
 
+// Shared test fixtures and argument names for the tools package tests.
+const (
+	statusSuccess   = "success"
+	resultTypeValue = "streams"
+	errorTypeData   = "invalid"
+
+	argApp       = "app"
+	argSelector  = "selector"
+	argInterval  = "interval"
+	argLabel     = "label"
+	argStatus    = "status"
+	argEnv       = "env"
+	argTimerange = "timerange"
+
+	caseRFC3339    = "RFC3339"
+	caseNowKeyword = "now keyword"
+
+	valueNginx        = "nginx"
+	selectorNginx     = `{app="nginx"}`
+	selectorTest      = `{app="test"}`
+	timerange1h       = "1h"
+	timerange30m      = "30m"
+	timeNow           = "now"
+	timeNotParsable   = "not-a-time"
+	timeRandomString  = "random string"
+	timeRFC3339Sample = "2024-01-01T00:00:00Z"
+)
+
 func newPromptRequest(name string, args map[string]string) *mcp.GetPromptRequest {
 	return &mcp.GetPromptRequest{
 		Params: &mcp.GetPromptParams{
@@ -43,7 +71,7 @@ func TestErrorLogsPrompt_Definition(t *testing.T) {
 	var hasApp bool
 
 	for _, arg := range prompt.Arguments {
-		if arg.Name == "app" {
+		if arg.Name == argApp {
 			hasApp = true
 
 			if !arg.Required {
@@ -61,7 +89,7 @@ func TestErrorLogsPrompt_Handler(t *testing.T) {
 	handler := tools.ErrorLogsHandler()
 
 	req := newPromptRequest(promptErrorLogs, map[string]string{
-		"app": "nginx",
+		argApp: valueNginx,
 	})
 
 	result, err := handler(context.Background(), req)
@@ -83,7 +111,7 @@ func TestErrorLogsPrompt_Handler(t *testing.T) {
 		t.Fatalf("expected TextContent, got %T", msg.Content)
 	}
 
-	if !strings.Contains(textContent.Text, `{app="nginx"}`) {
+	if !strings.Contains(textContent.Text, selectorNginx) {
 		t.Errorf("expected LogQL with app=nginx, got: %s", textContent.Text)
 	}
 
@@ -96,7 +124,7 @@ func TestErrorLogsPrompt_DefaultTimerange(t *testing.T) {
 	handler := tools.ErrorLogsHandler()
 
 	req := newPromptRequest(promptErrorLogs, map[string]string{
-		"app": "nginx",
+		argApp: valueNginx,
 	})
 
 	result, err := handler(context.Background(), req)
@@ -133,8 +161,8 @@ func TestErrorLogsPrompt_CustomTimerange(t *testing.T) {
 	handler := tools.ErrorLogsHandler()
 
 	req := newPromptRequest(promptErrorLogs, map[string]string{
-		"app":       "nginx",
-		"timerange": "30m",
+		argApp:       valueNginx,
+		argTimerange: timerange30m,
 	})
 
 	result, err := handler(context.Background(), req)
@@ -159,16 +187,16 @@ func TestErrorLogsPrompt_InvalidTimerange(t *testing.T) {
 		name      string
 		timerange string
 	}{
-		{"random string", "banana"},
-		{"RFC3339", "2024-01-01T00:00:00Z"},
-		{"now keyword", "now"},
+		{timeRandomString, "banana"},
+		{caseRFC3339, timeRFC3339Sample},
+		{caseNowKeyword, timeNow},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := newPromptRequest(promptErrorLogs, map[string]string{
-				"app":       "nginx",
-				"timerange": tt.timerange,
+				argApp:       valueNginx,
+				argTimerange: tt.timerange,
 			})
 
 			_, err := handler(context.Background(), req)
@@ -197,7 +225,7 @@ func TestRateQueryPrompt_Definition(t *testing.T) {
 	var hasSelector bool
 
 	for _, arg := range prompt.Arguments {
-		if arg.Name == "selector" {
+		if arg.Name == argSelector {
 			hasSelector = true
 
 			if !arg.Required {
@@ -215,7 +243,7 @@ func TestRateQueryPrompt_Handler(t *testing.T) {
 	handler := tools.RateQueryHandler()
 
 	req := newPromptRequest(promptRateQuery, map[string]string{
-		"selector": `{app="nginx"}`,
+		argSelector: selectorNginx,
 	})
 
 	result, err := handler(context.Background(), req)
@@ -245,8 +273,8 @@ func TestRateQueryPrompt_CustomInterval(t *testing.T) {
 	handler := tools.RateQueryHandler()
 
 	req := newPromptRequest(promptRateQuery, map[string]string{
-		"selector": `{app="nginx"}`,
-		"interval": "15m",
+		argSelector: selectorNginx,
+		argInterval: "15m",
 	})
 
 	result, err := handler(context.Background(), req)
@@ -286,16 +314,16 @@ func TestRateQueryPrompt_InvalidInterval(t *testing.T) {
 		name     string
 		interval string
 	}{
-		{"random string", "foo"},
-		{"RFC3339", "2024-01-01T00:00:00Z"},
-		{"now keyword", "now"},
+		{timeRandomString, "foo"},
+		{caseRFC3339, timeRFC3339Sample},
+		{caseNowKeyword, timeNow},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := newPromptRequest(promptRateQuery, map[string]string{
-				"selector": `{app="nginx"}`,
-				"interval": tt.interval,
+				argSelector: selectorNginx,
+				argInterval: tt.interval,
 			})
 
 			_, err := handler(context.Background(), req)
@@ -321,7 +349,7 @@ func TestTopLabelValuesPrompt_Definition(t *testing.T) {
 		t.Error("expected non-empty description")
 	}
 
-	requiredArgs := map[string]bool{"selector": false, "label": false}
+	requiredArgs := map[string]bool{argSelector: false, argLabel: false}
 
 	for _, arg := range prompt.Arguments {
 		if _, ok := requiredArgs[arg.Name]; ok {
@@ -344,8 +372,8 @@ func TestTopLabelValuesPrompt_Handler(t *testing.T) {
 	handler := tools.TopLabelValuesHandler()
 
 	req := newPromptRequest(promptTopLabelValues, map[string]string{
-		"selector": `{app="nginx"}`,
-		"label":    "status",
+		argSelector: selectorNginx,
+		argLabel:    argStatus,
 	})
 
 	result, err := handler(context.Background(), req)
@@ -370,7 +398,7 @@ func TestTopLabelValuesPrompt_Handler(t *testing.T) {
 		t.Errorf("expected sum by in query, got: %s", textContent.Text)
 	}
 
-	if !strings.Contains(textContent.Text, "status") {
+	if !strings.Contains(textContent.Text, argStatus) {
 		t.Errorf("expected label name in query, got: %s", textContent.Text)
 	}
 }
@@ -379,9 +407,9 @@ func TestTopLabelValuesPrompt_CustomN(t *testing.T) {
 	handler := tools.TopLabelValuesHandler()
 
 	req := newPromptRequest(promptTopLabelValues, map[string]string{
-		"selector": `{app="nginx"}`,
-		"label":    "status",
-		"n":        "5",
+		argSelector: selectorNginx,
+		argLabel:    argStatus,
+		"n":         "5",
 	})
 
 	result, err := handler(context.Background(), req)
@@ -403,7 +431,7 @@ func TestErrorLogsPrompt_AppWithSpecialChars(t *testing.T) {
 	handler := tools.ErrorLogsHandler()
 
 	req := newPromptRequest(promptErrorLogs, map[string]string{
-		"app": "my-app.v2",
+		argApp: "my-app.v2",
 	})
 
 	result, err := handler(context.Background(), req)
@@ -425,8 +453,8 @@ func TestErrorLogsPrompt_WeekDuration(t *testing.T) {
 	handler := tools.ErrorLogsHandler()
 
 	req := newPromptRequest(promptErrorLogs, map[string]string{
-		"app":       "nginx",
-		"timerange": "1w",
+		argApp:       valueNginx,
+		argTimerange: "1w",
 	})
 
 	result, err := handler(context.Background(), req)
@@ -448,7 +476,7 @@ func TestRateQueryPrompt_MalformedSelector(t *testing.T) {
 	handler := tools.RateQueryHandler()
 
 	req := newPromptRequest(promptRateQuery, map[string]string{
-		"selector": `}) | evil`,
+		argSelector: `}) | evil`,
 	})
 
 	_, err := handler(context.Background(), req)
@@ -465,8 +493,8 @@ func TestTopLabelValuesPrompt_MalformedLabel(t *testing.T) {
 	handler := tools.TopLabelValuesHandler()
 
 	req := newPromptRequest(promptTopLabelValues, map[string]string{
-		"selector": `{app="nginx"}`,
-		"label":    `status"); drop`,
+		argSelector: selectorNginx,
+		argLabel:    `status"); drop`,
 	})
 
 	_, err := handler(context.Background(), req)
@@ -483,8 +511,8 @@ func TestTopLabelValuesPrompt_MalformedSelector(t *testing.T) {
 	handler := tools.TopLabelValuesHandler()
 
 	req := newPromptRequest(promptTopLabelValues, map[string]string{
-		"selector": "not-a-selector",
-		"label":    "status",
+		argSelector: "not-a-selector",
+		argLabel:    argStatus,
 	})
 
 	_, err := handler(context.Background(), req)
@@ -512,9 +540,9 @@ func TestTopLabelValuesPrompt_InvalidN(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := newPromptRequest(promptTopLabelValues, map[string]string{
-				"selector": `{app="nginx"}`,
-				"label":    "status",
-				"n":        tt.n,
+				argSelector: selectorNginx,
+				argLabel:    argStatus,
+				"n":         tt.n,
 			})
 
 			_, err := handler(context.Background(), req)
@@ -537,8 +565,8 @@ func TestTopLabelValuesPrompt_MissingArgs(t *testing.T) {
 		args map[string]string
 	}{
 		{"missing both", map[string]string{}},
-		{"missing label", map[string]string{"selector": `{app="nginx"}`}},
-		{"missing selector", map[string]string{"label": "status"}},
+		{"missing label", map[string]string{argSelector: selectorNginx}},
+		{"missing selector", map[string]string{argLabel: argStatus}},
 	}
 
 	for _, tt := range tests {

--- a/internal/tools/query_test.go
+++ b/internal/tools/query_test.go
@@ -16,12 +16,12 @@ import (
 func TestQueryHandler_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		resp := loki.QueryResponse{
-			Status: "success",
+			Status: statusSuccess,
 			Data: loki.QueryData{
-				ResultType: "streams",
+				ResultType: resultTypeValue,
 				Result: []loki.StreamResult{
 					{
-						Stream: map[string]string{"app": "test"},
+						Stream: map[string]string{argApp: "test"},
 						Values: [][]json.RawMessage{
 							{json.RawMessage(`"1609459200000000000"`), json.RawMessage(`"test log line"`)},
 						},
@@ -42,7 +42,7 @@ func TestQueryHandler_Success(t *testing.T) {
 	handler := tools.NewQueryHandler(client)
 
 	params := tools.QueryParams{
-		Query: `{app="test"}`,
+		Query: selectorTest,
 	}
 
 	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
@@ -65,8 +65,8 @@ func TestQueryHandler_WithTimeRange(t *testing.T) {
 		}
 
 		resp := loki.QueryResponse{
-			Status: "success",
-			Data:   loki.QueryData{ResultType: "streams", Result: []loki.StreamResult{}},
+			Status: statusSuccess,
+			Data:   loki.QueryData{ResultType: resultTypeValue, Result: []loki.StreamResult{}},
 		}
 		w.Header().Set("Content-Type", "application/json")
 
@@ -81,9 +81,9 @@ func TestQueryHandler_WithTimeRange(t *testing.T) {
 	handler := tools.NewQueryHandler(client)
 
 	params := tools.QueryParams{
-		Query: `{app="test"}`,
-		Start: "1h",
-		End:   "now",
+		Query: selectorTest,
+		Start: timerange1h,
+		End:   timeNow,
 	}
 
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
@@ -98,12 +98,12 @@ func TestQueryHandler_RelativeTime(t *testing.T) {
 		input string
 		valid bool
 	}{
-		{"hours", "1h", true},
-		{"minutes", "30m", true},
+		{"hours", timerange1h, true},
+		{"minutes", timerange30m, true},
 		{"days", "7d", true},
-		{"now", "now", true},
-		{"rfc3339", "2024-01-01T00:00:00Z", true},
-		{"invalid", "invalid", false},
+		{timeNow, timeNow, true},
+		{"rfc3339", timeRFC3339Sample, true},
+		{errorTypeData, errorTypeData, false},
 	}
 
 	for _, tt := range tests {
@@ -147,8 +147,8 @@ func TestQueryHandler_InvalidStartTime(t *testing.T) {
 	handler := tools.NewQueryHandler(client)
 
 	params := tools.QueryParams{
-		Query: `{app="test"}`,
-		Start: "not-a-time",
+		Query: selectorTest,
+		Start: timeNotParsable,
 	}
 
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
@@ -172,7 +172,7 @@ func TestQueryHandler_LokiError(t *testing.T) {
 	handler := tools.NewQueryHandler(client)
 
 	params := tools.QueryParams{
-		Query: `{app="test"}`,
+		Query: selectorTest,
 	}
 
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)

--- a/internal/tools/series_test.go
+++ b/internal/tools/series_test.go
@@ -25,10 +25,10 @@ func TestSeriesHandler_Success(t *testing.T) {
 		}
 
 		resp := loki.SeriesResponse{
-			Status: "success",
+			Status: statusSuccess,
 			Data: []map[string]string{
-				{"app": "nginx", "env": "prod"},
-				{"app": "nginx", "env": "staging"},
+				{argApp: valueNginx, argEnv: "prod"},
+				{argApp: valueNginx, argEnv: "staging"},
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -44,7 +44,7 @@ func TestSeriesHandler_Success(t *testing.T) {
 	handler := tools.NewSeriesHandler(client)
 
 	params := tools.SeriesParams{
-		Match: []string{`{app="nginx"}`},
+		Match: []string{selectorNginx},
 	}
 
 	result, output, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
@@ -68,7 +68,7 @@ func TestSeriesHandler_MultipleMatchers(t *testing.T) {
 			t.Errorf("expected 2 match[] parameters, got %d", len(matches))
 		}
 
-		resp := loki.SeriesResponse{Status: "success", Data: []map[string]string{}}
+		resp := loki.SeriesResponse{Status: statusSuccess, Data: []map[string]string{}}
 		w.Header().Set("Content-Type", "application/json")
 
 		err := json.NewEncoder(w).Encode(resp)
@@ -82,7 +82,7 @@ func TestSeriesHandler_MultipleMatchers(t *testing.T) {
 	handler := tools.NewSeriesHandler(client)
 
 	params := tools.SeriesParams{
-		Match: []string{`{app="nginx"}`, `{app="redis"}`},
+		Match: []string{selectorNginx, `{app="redis"}`},
 	}
 
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
@@ -124,7 +124,7 @@ func TestSeriesHandler_LokiError(t *testing.T) {
 	handler := tools.NewSeriesHandler(client)
 
 	params := tools.SeriesParams{
-		Match: []string{`{app="test"}`},
+		Match: []string{selectorTest},
 	}
 
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)

--- a/internal/tools/stats_test.go
+++ b/internal/tools/stats_test.go
@@ -25,7 +25,7 @@ func TestStatsHandler_Success(t *testing.T) {
 		}
 
 		resp := loki.StatsResponse{
-			Status: "success",
+			Status: statusSuccess,
 			Data: loki.StatsData{
 				Streams: 100,
 				Chunks:  5000,
@@ -46,7 +46,7 @@ func TestStatsHandler_Success(t *testing.T) {
 	handler := tools.NewStatsHandler(client)
 
 	params := tools.StatsParams{
-		Query: `{app="nginx"}`,
+		Query: selectorNginx,
 	}
 
 	result, output, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
@@ -85,7 +85,7 @@ func TestStatsHandler_WithTimeRange(t *testing.T) {
 		}
 
 		resp := loki.StatsResponse{
-			Status: "success",
+			Status: statusSuccess,
 			Data:   loki.StatsData{},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -101,9 +101,9 @@ func TestStatsHandler_WithTimeRange(t *testing.T) {
 	handler := tools.NewStatsHandler(client)
 
 	params := tools.StatsParams{
-		Query: `{app="nginx"}`,
+		Query: selectorNginx,
 		Start: "24h",
-		End:   "now",
+		End:   timeNow,
 	}
 
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)
@@ -145,7 +145,7 @@ func TestStatsHandler_LokiError(t *testing.T) {
 	handler := tools.NewStatsHandler(client)
 
 	params := tools.StatsParams{
-		Query: `{app="test"}`,
+		Query: selectorTest,
 	}
 
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, params)


### PR DESCRIPTION
# Pull Request

## Summary

Unblock Renovate on this repository. Two things kept the required Lint check red on master, which in turn blocked Renovate's PRs: the lint jobs ran golangci-lint at the latest release (now v2.12.2), and that release flags repeated string literals via goconst across the test suite and the prompt definitions. This PR fixes every goconst finding, pins the linter, and migrates the Renovate config onto the shared lexfrei preset.

## Changes

- Hoist every repeated string literal flagged by goconst to a named constant, reusing the existing `appNginx` and `statusSuccess` constants and grouping related fixture and argument-name constants per package. No behaviour change.
- Pin golangci-lint to `v2.12.2` in both lint jobs (`pr.yaml` previously used `version: latest`; `ci.yaml` left it unset so the action installed latest) and annotate the version with a renovate comment so it is bumped through controlled PRs.
- Migrate `.github/renovate.json` to extend `github>lexfrei/renovate-config`, dropping the automerge, labelling, PR-limit and gomod-tidy policy now provided by the preset. Keep only the repo-specific overrides the preset does not cover: range pinning, the Containerfile Go-image pin, Docker major-update handling, and the custom managers that bump the Go version in workflows and `go.mod`. The preset's regex customManager picks up the newly pinned golangci-lint version via its comment annotation.

## Testing

- [x] All tests pass locally (`go test ./...`)
- [x] Linters pass locally (`golangci-lint run` — zero issues with `--max-issues-per-linter=0 --max-same-issues=0`)
- [x] Markdown linting passes (`markdownlint **/*.md`)
- [x] Manual testing completed (if applicable) — `renovate-config-validator` validates the new config successfully

## Documentation

- [ ] README updated (if needed)
- [x] Code comments added for complex logic

## Checklist

- [x] Commit messages follow semantic format (`type(scope): description`)
- [x] No secrets or credentials in code
- [x] Breaking changes documented (if any) — none
- [ ] Related issues referenced (if any)

## Additional Notes

The repeated-literal fixes are mechanical: each constant holds exactly the value of the literals it replaces, and the JSON fixtures held in raw string blocks were left untouched. The constants were applied with an AST-based rewrite so a literal value appearing inside a larger raw string (for example `nginx` inside `{app="nginx"}`) is never confused with a standalone literal of the same text.
